### PR TITLE
Remove frontend token gate for Express backend

### DIFF
--- a/components/PatientList/PatientListArchived/PatientOptionsMenu.tsx
+++ b/components/PatientList/PatientListArchived/PatientOptionsMenu.tsx
@@ -4,8 +4,7 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Edit, Archive } from '@/public';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
-import { RootState } from '@/store';
+import { BACKEND_BASE_URL } from '@/config';
 
 type Props = {
   patientId: string;
@@ -22,27 +21,18 @@ export default function PatientOptionsMenu({
   showToast,
   onPatientUpdated,
 }: Props) {
-  const token = useSelector((state: RootState) => state.auth.token);
   const router = useRouter();
   const [loading, setLoading] = useState(false);
 
   const archivePatient = async () => {
-    if (!token) {
-      alert('Debes estar autenticado para archivar');
-      return;
-    }
     setLoading(true);
     try {
-      const res = await fetch(
-        `https://comfortable-manifestation-production.up.railway.app/api/Patient/pacientes/${patientId}/archive`,
-        {
-          method: 'PUT',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
+      const res = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/archive`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
       if (!res.ok) throw new Error('Error al archivar');
       router.refresh();
       showToast('El paciente fue archivado', 'success');
@@ -59,22 +49,14 @@ export default function PatientOptionsMenu({
   };
 
   const unarchivePatient = async () => {
-    if (!token) {
-      alert('Debes estar autenticado para desarchivar');
-      return;
-    }
     setLoading(true);
     try {
-      const res = await fetch(
-        `https://comfortable-manifestation-production.up.railway.app/api/Patient/pacientes/${patientId}/unarchive`,
-        {
-          method: 'PUT',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
+      const res = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/unarchive`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
       if (!res.ok) throw new Error('Error al desarchivar');
       router.refresh();
       showToast('El paciente fue desarchivado', 'success');

--- a/hooks/useChangePassword.ts
+++ b/hooks/useChangePassword.ts
@@ -1,29 +1,22 @@
 'use client';
 
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
-
 import { BACKEND_BASE_URL } from '@/config';
 import { ChangePasswordPayload } from '@/types';
-import type { RootState } from '@/store';
 
 export function useChangePassword() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const token = useSelector((state: RootState) => state.auth.token);
 
   const changePassword = async (payload: ChangePasswordPayload): Promise<boolean> => {
     setLoading(true);
     setError(null);
 
     try {
-      if (!token) throw new Error('Token no disponible');
-
-      const res = await fetch(`${BACKEND_BASE_URL}/api/User/me/password`, {
+      const res = await fetch(`${BACKEND_BASE_URL}/api/users/me/password`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(payload),
       });

--- a/hooks/useLogin.ts
+++ b/hooks/useLogin.ts
@@ -37,7 +37,7 @@ export function useLogin() {
     };
 
     try {
-      const res = await fetch(`${BACKEND_BASE_URL}/api/Auth/login`, {
+      const res = await fetch(`${BACKEND_BASE_URL}/api/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
@@ -51,8 +51,10 @@ export function useLogin() {
         const data = await res.json();
         const token = data.token;
 
-        dispatch(setToken(token));
-        sessionStorage.setItem('token', token);
+        if (token) {
+          dispatch(setToken(token));
+          sessionStorage.setItem('token', token);
+        }
 
         return { success: true, alert: alertSuccess };
       }

--- a/hooks/useRequestReset.ts
+++ b/hooks/useRequestReset.ts
@@ -13,7 +13,7 @@ export function useRequestReset() {
     setError(null);
 
     try {
-      const res = await fetch(`${BACKEND_BASE_URL}/api/Auth/request-password-reset`, {
+      const res = await fetch(`${BACKEND_BASE_URL}/api/auth/request-password-reset`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/hooks/useResetPassword.ts
+++ b/hooks/useResetPassword.ts
@@ -14,7 +14,7 @@ export function useResetPassword() {
     setError(null);
 
     try {
-      const res = await fetch(`${BACKEND_BASE_URL}/api/Auth/verify-password-reset-code`, {
+      const res = await fetch(`${BACKEND_BASE_URL}/api/auth/verify-password-reset-code`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/hooks/useSignup.ts
+++ b/hooks/useSignup.ts
@@ -17,7 +17,7 @@ export function useSignup() {
     const signupPayload = transformFormDataToSignupPayload(formData);
 
     try {
-      const res = await fetch(`${BACKEND_BASE_URL}/api/User/register`, {
+      const res = await fetch(`${BACKEND_BASE_URL}/api/auth/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/hooks/useVerification.ts
+++ b/hooks/useVerification.ts
@@ -17,7 +17,7 @@ export function useVerification() {
     setError(null);
 
     try {
-      const res = await fetch(`${BACKEND_BASE_URL}/api/User/verify-registration`, {
+      const res = await fetch(`${BACKEND_BASE_URL}/api/auth/verify-registration`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -31,11 +31,13 @@ export function useVerification() {
         throw new Error(responseBody.message || 'Error al verificar');
       }
 
-      // Si la verificaión funcionó seteo token
+      // Si la verificación retornó un token lo guardamos, pero no es obligatorio
       const token = responseBody.token;
 
-      dispatch(setToken(token));
-      sessionStorage.setItem('token', token);
+      if (token) {
+        dispatch(setToken(token));
+        sessionStorage.setItem('token', token);
+      }
 
       return true;
     } catch (err) {

--- a/store/thunks/materialsThunks.ts
+++ b/store/thunks/materialsThunks.ts
@@ -1,7 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { BACKEND_BASE_URL } from '@/config';
-import type { RootState } from '@/store';
 import type { BackendMaterial, CreateMaterialPayload, DeleteMaterialPayload } from '@/types';
 
 // Traer todos los materiales de un paciente
@@ -10,15 +9,8 @@ export const fetchAllMaterials = createAsyncThunk<
   number,
   { rejectValue: string }
 >('backendPatients/fetchAllMaterials', async (patientId, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patientId}/materials`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/materials`);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -39,17 +31,9 @@ export const fetchOneMaterial = createAsyncThunk<
   { patientId: number; materialId: number },
   { rejectValue: string }
 >('backendPatients/fetchOneMaterial', async ({ patientId, materialId }, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
     const response = await fetch(
-      `${BACKEND_BASE_URL}/api/Patient/${patientId}/materials/${materialId}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
+      `${BACKEND_BASE_URL}/api/patients/${patientId}/materials/${materialId}`
     );
 
     if (!response.ok) {
@@ -71,15 +55,11 @@ export const createMaterial = createAsyncThunk<
   CreateMaterialPayload,
   { rejectValue: string }
 >('backendPatients/createMaterial', async ({ patientId, materialData }, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patientId}/materials`, {
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/materials`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(materialData),
     });
@@ -107,17 +87,13 @@ export const editMaterial = createAsyncThunk<
   },
   { rejectValue: string }
 >('backendPatients/editMaterial', async ({ patientId, materialId, materialData }, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
     const response = await fetch(
-      `${BACKEND_BASE_URL}/api/Patient/${patientId}/materials/${materialId}`,
+      `${BACKEND_BASE_URL}/api/patients/${patientId}/materials/${materialId}`,
       {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(materialData),
       }
@@ -142,17 +118,11 @@ export const deleteMaterial = createAsyncThunk<
   DeleteMaterialPayload,
   { rejectValue: string }
 >('backendPatients/deleteMaterial', async ({ patientId, materialId }, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
     const response = await fetch(
-      `${BACKEND_BASE_URL}/api/Patient/${patientId}/materials/${materialId}`,
+      `${BACKEND_BASE_URL}/api/patients/${patientId}/materials/${materialId}`,
       {
         method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
       }
     );
 

--- a/store/thunks/notesThunks.ts
+++ b/store/thunks/notesThunks.ts
@@ -1,22 +1,14 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { BACKEND_BASE_URL } from '@/config';
-import type { RootState } from '@/store';
 import type { BackendNote, CreateNotePayload, DeleteNotePayload } from '@/types';
 
 // Traer todas las notas de un paciente
 export const fetchAllNotes = createAsyncThunk<BackendNote[], number, { rejectValue: string }>(
   'backendPatients/fetchAllNotes',
   async (patientId, thunkApi) => {
-    const state = thunkApi.getState() as RootState;
-    const token = state.auth.token;
-
     try {
-      const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patientId}/notes`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/notes`);
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -38,15 +30,8 @@ export const fetchOneNote = createAsyncThunk<
   { patientId: number; noteId: number },
   { rejectValue: string }
 >('backendPatients/fetchOneNote', async ({ patientId, noteId }, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patientId}/notes/${noteId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/notes/${noteId}`);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -65,15 +50,11 @@ export const fetchOneNote = createAsyncThunk<
 export const createNote = createAsyncThunk<BackendNote, CreateNotePayload, { rejectValue: string }>(
   'backendPatients/createNote',
   async ({ patientId, noteData }, thunkApi) => {
-    const state = thunkApi.getState() as RootState;
-    const token = state.auth.token;
-
     try {
-      const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patientId}/notes`, {
+      const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/notes`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(noteData),
       });
@@ -98,15 +79,11 @@ export const editNote = createAsyncThunk<
   { patientId: number; noteId: number; noteData: { title: string; content: string; date: string } },
   { rejectValue: string }
 >('backendPatients/editNote', async ({ patientId, noteId, noteData }, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patientId}/notes/${noteId}`, {
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${patientId}/notes/${noteId}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(noteData),
     });
@@ -128,16 +105,13 @@ export const editNote = createAsyncThunk<
 export const deleteNote = createAsyncThunk<string, DeleteNotePayload, { rejectValue: string }>(
   'backendPatients/deleteNote',
   async ({ patientId, noteId }, thunkApi) => {
-    const state = thunkApi.getState() as RootState;
-    const token = state.auth.token;
-
     try {
-      const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patientId}/notes/${noteId}`, {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await fetch(
+        `${BACKEND_BASE_URL}/api/patients/${patientId}/notes/${noteId}`,
+        {
+          method: 'DELETE',
+        }
+      );
 
       if (!response.ok) {
         const errorText = await response.text();

--- a/store/thunks/patientsThunks.ts
+++ b/store/thunks/patientsThunks.ts
@@ -1,7 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { BACKEND_BASE_URL } from '@/config';
-import type { RootState } from '@/store';
 import { mapEditPatientToBackendPatient } from '@/utils';
 import type { BackendPatient, BackendEditPatient, BackendNewPatient } from '@/types';
 
@@ -9,19 +8,8 @@ import type { BackendPatient, BackendEditPatient, BackendNewPatient } from '@/ty
 export const fetchPatients = createAsyncThunk<BackendPatient[], void, { rejectValue: string }>(
   'backendPatients/fetchPatients',
   async (_, thunkApi) => {
-    const state = thunkApi.getState() as RootState;
-    const token = state.auth.token;
-
-    if (!token) {
-      return thunkApi.rejectWithValue('Token no disponible');
-    }
-
     try {
-      const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/pacientes`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await fetch(`${BACKEND_BASE_URL}/api/patients`);
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -43,15 +31,8 @@ export const fetchArchivedPatients = createAsyncThunk<
   void,
   { rejectValue: string }
 >('backendPatients/fetchArchivedPatients', async (_, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/patients/archived`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients/archived`);
 
     if (!response.ok) {
       const errorText = await response.text();
@@ -70,15 +51,8 @@ export const fetchArchivedPatients = createAsyncThunk<
 export const fetchOnePatient = createAsyncThunk<BackendPatient, number, { rejectValue: string }>(
   'backendPatients/fetchOnePatient',
   async (id, thunkApi) => {
-    const state = thunkApi.getState() as RootState;
-    const token = state.auth.token;
-
     try {
-      const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${id}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${id}`);
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -100,15 +74,11 @@ export const createBackendPatient = createAsyncThunk<
   BackendNewPatient,
   { rejectValue: { detail: string } }
 >('backendPatients/createBackendPatient', async (newPatient, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient`, {
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(newPatient),
     });
@@ -131,15 +101,9 @@ export const deleteBackendPatient = createAsyncThunk<
   number,
   { rejectValue: string }
 >('backendPatients/deleteBackendPatient', async (id, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${id}`, {
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${id}`, {
       method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
 
     if (response.status !== 204) {
@@ -160,16 +124,12 @@ export const editBackendPatient = createAsyncThunk<
   BackendEditPatient,
   { rejectValue: string }
 >('backendPatients/editBackendPatient', async (patient, thunkApi) => {
-  const state = thunkApi.getState() as RootState;
-  const token = state.auth.token;
-
   const payload = mapEditPatientToBackendPatient(patient);
 
   try {
-    const response = await fetch(`${BACKEND_BASE_URL}/api/Patient/${patient.id}`, {
+    const response = await fetch(`${BACKEND_BASE_URL}/api/patients/${patient.id}`, {
       method: 'PUT',
       headers: {
-        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),

--- a/store/thunks/userThunks.ts
+++ b/store/thunks/userThunks.ts
@@ -1,20 +1,13 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { BACKEND_BASE_URL } from '@/config';
-import type { RootState } from '@/store';
 import type { UpdateUserPayload } from '@/types';
 
 export const fetchUser = createAsyncThunk('user/fetchUser', async (_, thunkApi) => {
   try {
-    const state = thunkApi.getState() as RootState;
-    const token = state.auth.token;
-
-    if (!token) throw new Error('Token no disponible');
-
-    const res = await fetch(`${BACKEND_BASE_URL}/api/User/me`, {
+    const res = await fetch(`${BACKEND_BASE_URL}/api/users/me`, {
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
     });
 
@@ -30,23 +23,16 @@ export const fetchUser = createAsyncThunk('user/fetchUser', async (_, thunkApi) 
   }
 });
 
-export const updateUser = createAsyncThunk<void, UpdateUserPayload, { state: RootState }>(
+export const updateUser = createAsyncThunk<void, UpdateUserPayload>(
   'user/updateUser',
   async (userData, thunkApi) => {
-    const token = thunkApi.getState().auth.token;
-
-    if (!token) {
-      return thunkApi.rejectWithValue('Token no disponible');
-    }
-
     const [name, surname = ''] = userData.nombre.trim().split(' ');
 
     try {
-      const res = await fetch(`${BACKEND_BASE_URL}/api/User/me/edit`, {
+      const res = await fetch(`${BACKEND_BASE_URL}/api/users/me`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           name,


### PR DESCRIPTION
## Summary
- allow patient archive menu actions to call Express endpoints without token headers
- remove bearer token requirements from patient, note, material, and user thunks
- handle optional tokens in authentication hooks so the UI works without backend tokens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fff76105c0832e8f93766e102299f6